### PR TITLE
Remove the "intro" page on install due to a Firefox bug

### DIFF
--- a/src/shared/js/__tests__/background.test.js
+++ b/src/shared/js/__tests__/background.test.js
@@ -14,61 +14,6 @@ afterEach(() => {
 
 // Note: we partially mock the browser APIs in setupTests.js.
 
-describe('background script: open tab on install', () => {
-  it('sets a listener for the onInstalled event', () => {
-    const ext = require('../extension')
-    require('../background')
-    expect(ext.runtime.onInstalled.addListener).toHaveBeenCalled()
-  })
-
-  it('opens the welcome page after install', () => {
-    const ext = require('../extension')
-    require('../background')
-    const handler = ext.runtime.onInstalled.addListener.mock.calls[0][0]
-    handler({ reason: 'install' })
-    expect(ext.tabs.create).toHaveBeenCalledWith({
-      url: 'https://tab.gladly.io/search/first-search/',
-    })
-  })
-
-  it('does not open a welcome page after extension update', () => {
-    const ext = require('../extension')
-    require('../background')
-    const handler = ext.runtime.onInstalled.addListener.mock.calls[0][0]
-    handler({ reason: 'update' })
-    expect(ext.tabs.create).not.toHaveBeenCalled()
-  })
-
-  it('gracefully handles errors with setting the onInstalled listener', () => {
-    const ext = require('../extension')
-    ext.runtime.onInstalled.addListener.mockImplementationOnce(() => {
-      throw new Error('Whoops!')
-    })
-
-    // Suppress expected console error.
-    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
-
-    // Should not throw.
-    require('../background')
-  })
-
-  it('gracefully handles errors when opening the welcome page tab', () => {
-    const ext = require('../extension')
-    require('../background')
-    ext.tabs.create.mockImplementationOnce(() => {
-      throw new Error('Whoops!')
-    })
-
-    // Suppress expected console error.
-    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
-
-    const handler = ext.runtime.onInstalled.addListener.mock.calls[0][0]
-
-    // Should not throw.
-    handler({ reason: 'install' })
-  })
-})
-
 describe('background script: open tab after uninstall', () => {
   it('sets the post-uninstall URL', () => {
     const ext = require('../extension')

--- a/src/shared/js/background.js
+++ b/src/shared/js/background.js
@@ -3,22 +3,10 @@
 import ext from './extension'
 import config from './config'
 
-// On install, open a welcome tab.
-// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled
-try {
-  ext.runtime.onInstalled.addListener(details => {
-    try {
-      if (details.reason === ext.runtime.OnInstalledReason.INSTALL) {
-        const postInstallURL = 'https://tab.gladly.io/search/first-search/'
-        ext.tabs.create({ url: postInstallURL })
-      }
-    } catch (e) {
-      console.error(e)
-    }
-  })
-} catch (e) {
-  console.error(e)
-}
+// We cannot open a welcome page on install, because there's
+// a bug in Firefox that will hide the confirmation dialog
+// for changing the default search engine:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1544271
 
 // On uninstall, open a post-uninstall page to get feedback.
 try {


### PR DESCRIPTION
This UI problem means that Firefox will hide the confirmation dialog for changing the default search engine when opening a new page on install:
https://bugzilla.mozilla.org/show_bug.cgi?id=1544271
